### PR TITLE
Fix indefinite spelling

### DIFF
--- a/reverb/client.py
+++ b/reverb/client.py
@@ -487,7 +487,7 @@ class Client:
 
     Args:
       timeout: Timeout in seconds to wait for server response. By default no
-        deadline is set and call will block indefinetely until server responds.
+        deadline is set and call will block indefinitely until server responds.
 
     Returns:
       A dictionary mapping table names to their associated `TableInfo`

--- a/reverb/pybind.cc
+++ b/reverb/pybind.cc
@@ -463,7 +463,7 @@ PYBIND11_MODULE(libpybind, m) {
       .def("Reset", &Client::Reset, py::call_guard<py::gil_scoped_release>())
       .def("ServerInfo",
            [](Client *client, int timeout_sec) {
-             // Wait indefinetely for server to startup when timeout not
+             // Wait indefinitely for server to startup when timeout not
              // provided.
              auto timeout = timeout_sec > 0 ? absl::Seconds(timeout_sec)
                                             : absl::InfiniteDuration();


### PR DESCRIPTION
## Summary
- fix spelling errors in client.py and pybind.cc

## Testing
- `bash run_python_tests.sh` *(fails: ModuleNotFoundError: No module named 'absl')*

------
https://chatgpt.com/codex/tasks/task_i_686a3cdb73808327bf7063fe94637878